### PR TITLE
project/update-version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,13 @@ plugins {
 
 }
 
+// lock the buildscript classpath (plugins) of root project
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
 tasks {
 
     // add a custom "clean" task to root project
@@ -32,6 +39,18 @@ tasks {
         doLast {
             delete("${rootDir}/build")
         }
+    }
+
+    // Refresh all Gradle dependency lockfiles in one invocation: root project,
+    // every subproject, and their buildscript classpaths. New subprojects are
+    // picked up automatically, so there is no list to keep in sync.
+    // Usage: ./gradlew updateGradleLockfiles --write-locks
+    register("updateGradleLockfiles") {
+        group = "help"
+        description = "Resolves all dependencies of all projects to refresh the lockfiles (run with --write-locks)."
+        dependsOn(allprojects.flatMap { p ->
+            listOf(p.tasks.named("dependencies"), p.tasks.named("buildEnvironment"))
+        })
     }
 
     dependencyUpdates {
@@ -44,6 +63,11 @@ tasks {
 }
 
 allprojects {
+
+    // lock all dependency configurations in every project ---------------------
+    dependencyLocking {
+        lockAllConfigurations()
+    }
 
     // load user-specific properties -------------------------------------------
     val userPropertiesFile = file("${rootDir}/gradle.user.properties")
@@ -61,12 +85,31 @@ allprojects {
 
 }
 
+subprojects {
+
+    // lock the buildscript classpath (plugins) of every subproject ------------
+    buildscript {
+        configurations.classpath {
+            resolutionStrategy.activateDependencyLocking()
+        }
+    }
+
+}
+
 // special settings for IntelliJ IDEA
 idea {
     project {
         jdkName = "17"
         languageLevel = org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(JavaVersion.VERSION_11)
         vcs = "Git"
+    }
+}
+
+// Fail fast if updateGradleLockfiles is run without --write-locks, instead of
+// silently resolving dependencies without rewriting the lockfiles.
+gradle.taskGraph.whenReady {
+    if (hasTask(":updateGradleLockfiles") && !gradle.startParameter.isWriteDependencyLocks) {
+        throw GradleException("Run with --write-locks: ./gradlew updateGradleLockfiles --write-locks")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
     // Gradle Versions Plugin
     // https://github.com/ben-manes/gradle-versions-plugin
-    id("com.github.ben-manes.versions") version "0.54.0"
+    alias(libs.plugins.versions)
 
 }
 

--- a/buildscript-gradle.lockfile
+++ b/buildscript-gradle.lockfile
@@ -1,0 +1,19 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew dependencies --write-locks
+com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.54.0=classpath
+com.github.ben-manes:gradle-versions-plugin:0.54.0=classpath
+com.squareup.moshi:moshi-kotlin:1.12.0=classpath
+com.squareup.moshi:moshi:1.12.0=classpath
+com.squareup.okhttp3:okhttp:4.12.0=classpath
+com.squareup.okio:okio-jvm:3.6.0=classpath
+com.squareup.okio:okio:3.6.0=classpath
+org.jetbrains.kotlin:kotlin-bom:2.0.21=classpath
+org.jetbrains.kotlin:kotlin-reflect:2.3.21=classpath
+org.jetbrains.kotlin:kotlin-stdlib-common:2.3.21=classpath
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.21=classpath
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.21=classpath
+org.jetbrains.kotlin:kotlin-stdlib:2.3.21=classpath
+org.jetbrains:annotations:13.0=classpath
+empty=

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # PROJECT ----------------------------------------------------------------------
 
 group = org.jarhc.gradle
-version = 1.2.1-SNAPSHOT
+version = 3.1.0-SNAPSHOT
 description = JarHC Gradle Plugin
 
 # GRADLE SETTINGS --------------------------------------------------------------

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+# Version catalog for the JarHC Gradle Plugin build.
+# https://docs.gradle.org/current/userguide/version_catalogs.html
+
+[versions]
+jarhc = "3.1.0"
+junit = "6.1.1"
+mockito = "5.23.0"
+ben-manes-versions = "0.54.0"
+plugin-publish = "2.1.1"
+shadow = "9.4.3"
+sonarqube = "7.3.1.8318"
+grgit = "5.3.3"
+
+[libraries]
+jarhc = { module = "org.jarhc:jarhc", version.ref = "jarhc" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+
+[plugins]
+versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
+plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -202,10 +202,6 @@ tasks.named<Task>("check") {
 // JaCoCo coverage report
 val jacocoTestReportXml: String = "${layout.buildDirectory.get()}/reports/jacoco/test/report.xml"
 
-jacoco {
-    toolVersion = "0.8.10"
-}
-
 tasks.jacocoTestReport {
 
     // run all tests first

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -23,16 +23,16 @@ plugins {
 
     // Gradle Publish plugin
     // https://plugins.gradle.org/docs/publish-plugin
-    id("com.gradle.plugin-publish") version "2.1.1"
+    alias(libs.plugins.plugin.publish)
 
     // Gradle Shadow plugin
-    id("com.gradleup.shadow") version "9.4.3"
+    alias(libs.plugins.shadow)
 
     // run Sonar analysis
-    id("org.sonarqube") version "7.3.1.8318"
+    alias(libs.plugins.sonarqube)
 
     // get current Git branch name
-    id("org.ajoberstar.grgit") version "5.3.3"
+    alias(libs.plugins.grgit)
 }
 
 // Preconditions based on which tasks should be executed -----------------------
@@ -53,8 +53,8 @@ gradle.taskGraph.whenReady {
 
 dependencies {
 
-    // JarHC 3.1.0
-    implementation("org.jarhc:jarhc:3.1.0")
+    // JarHC
+    implementation(libs.jarhc)
 
     // Gradle API
     // (this is required because the Gradle API dependency gets removed by the Shadow plugin)
@@ -62,9 +62,9 @@ dependencies {
     testImplementation(gradleApi())
 
     // JUnit and Mockito
-    testImplementation("org.junit.jupiter:junit-jupiter:6.1.1")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.23.0")
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.mockito.junit.jupiter)
 }
 
 gradlePlugin {

--- a/jarhc-gradle-plugin/buildscript-gradle.lockfile
+++ b/jarhc-gradle-plugin/buildscript-gradle.lockfile
@@ -1,0 +1,48 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew dependencies --write-locks
+com.fasterxml.woodstox:woodstox-core:7.1.1=classpath
+com.google.code.gson:gson:2.13.2=classpath
+com.google.errorprone:error_prone_annotations:2.41.0=classpath
+com.googlecode.javaewah:JavaEWAH:1.2.3=classpath
+com.gradle.plugin-publish:com.gradle.plugin-publish.gradle.plugin:2.1.1=classpath
+com.gradle.publish:plugin-publish-plugin:2.1.1=classpath
+com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.4.3=classpath
+com.gradleup.shadow:shadow-gradle-plugin:9.4.3=classpath
+commons-codec:commons-codec:1.22.0=classpath
+commons-io:commons-io:2.22.0=classpath
+de.siegmar:fastcsv:3.7.0=classpath
+io.github.hakky54:ayza:10.0.3=classpath
+io.github.hakky54:sude:2.0.2=classpath
+org.ajoberstar.grgit:grgit-core:5.3.3=classpath
+org.ajoberstar.grgit:grgit-gradle:5.3.3=classpath
+org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin:5.3.3=classpath
+org.apache.ant:ant-launcher:1.10.17=classpath
+org.apache.ant:ant:1.10.17=classpath
+org.apache.commons:commons-compress:1.28.0=classpath
+org.apache.commons:commons-lang3:3.20.0=classpath
+org.apache.logging.log4j:log4j-api:2.26.0=classpath
+org.apache.logging.log4j:log4j-core:2.26.0=classpath
+org.apache.maven:maven-api-annotations:4.0.0-rc-5=classpath
+org.apache.maven:maven-api-xml:4.0.0-rc-5=classpath
+org.apache.maven:maven-model:3.6.3=classpath
+org.apache.maven:maven-xml:4.0.0-rc-5=classpath
+org.bouncycastle:bcprov-jdk18on:1.84=classpath
+org.codehaus.plexus:plexus-utils:4.0.3=classpath
+org.codehaus.plexus:plexus-xml:4.1.1=classpath
+org.codehaus.woodstox:stax2-api:4.2.2=classpath
+org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r=classpath
+org.gradle.plugin:compatibility-plugin:1.0.0=classpath
+org.jdom:jdom2:2.0.6.1=classpath
+org.jetbrains.kotlin:kotlin-metadata-jvm:2.4.0=classpath
+org.jetbrains.kotlin:kotlin-stdlib:2.3.21=classpath
+org.jetbrains:annotations:13.0=classpath
+org.slf4j:slf4j-api:1.7.36=classpath
+org.sonarqube:org.sonarqube.gradle.plugin:7.3.1.8318=classpath
+org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:7.3.1.8318=classpath
+org.sonarsource.scanner.lib:sonar-scanner-download-cache:4.1.1.1633=classpath
+org.sonarsource.scanner.lib:sonar-scanner-java-library-batch-interface:4.1.1.1633=classpath
+org.sonarsource.scanner.lib:sonar-scanner-java-library:4.1.1.1633=classpath
+org.vafer:jdependency:2.16=classpath
+empty=

--- a/jarhc-gradle-plugin/gradle.lockfile
+++ b/jarhc-gradle-plugin/gradle.lockfile
@@ -1,0 +1,56 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew :jarhc-gradle-plugin:dependencies --write-locks
+com.google.code.gson:gson:2.13.2=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+com.google.errorprone:error_prone_annotations:2.41.0=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+commons-codec:commons-codec:1.21.0=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+net.bytebuddy:byte-buddy-agent:1.17.7=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+net.bytebuddy:byte-buddy:1.17.7=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.apache.httpcomponents:httpclient:4.5.14=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.httpcomponents:httpcore:4.4.16=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-api:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-connector-basic:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-impl:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-named-locks:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-spi:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-supplier:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-transport-file:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-transport-http:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven.resolver:maven-resolver-util:1.9.27=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-artifact:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-builder-support:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-model-builder:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-model:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-repository-metadata:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apache.maven:maven-resolver-provider:3.9.12=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.apiguardian:apiguardian-api:1.1.2=functionalTestCompileClasspath,testCompileClasspath
+org.codehaus.plexus:plexus-interpolation:1.29=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.codehaus.plexus:plexus-utils:3.6.1=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.jacoco:org.jacoco.agent:0.8.14=jacocoAgent,jacocoAnt
+org.jacoco:org.jacoco.ant:0.8.14=jacocoAnt
+org.jacoco:org.jacoco.core:0.8.14=jacocoAnt
+org.jacoco:org.jacoco.report:0.8.14=jacocoAnt
+org.jarhc:jarhc:3.1.0=compileClasspath,functionalTestCompileClasspath,functionalTestRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.json:json:20260522=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.jspecify:jspecify:1.0.0=functionalTestCompileClasspath,testCompileClasspath
+org.junit.jupiter:junit-jupiter-api:6.1.1=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:6.1.1=functionalTestRuntimeClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-params:6.1.1=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter:6.1.1=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-commons:6.1.1=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:6.1.1=functionalTestRuntimeClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:6.1.1=functionalTestRuntimeClasspath,testRuntimeClasspath
+org.junit:junit-bom:6.1.1=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.mockito:mockito-core:5.23.0=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.mockito:mockito-junit-jupiter:5.23.0=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.objenesis:objenesis:3.3=functionalTestRuntimeClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=functionalTestCompileClasspath,functionalTestRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.ow2.asm:asm-commons:9.9=jacocoAnt
+org.ow2.asm:asm-tree:9.9=jacocoAnt
+org.ow2.asm:asm:9.10.1=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.ow2.asm:asm:9.9=jacocoAnt
+org.slf4j:jcl-over-slf4j:2.0.18=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.slf4j:jul-to-slf4j:2.0.18=functionalTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.slf4j:slf4j-api:2.0.18=compileClasspath,functionalTestCompileClasspath,functionalTestRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,functionalTestAnnotationProcessor,shadow,testAnnotationProcessor

--- a/settings-gradle.lockfile
+++ b/settings-gradle.lockfile
@@ -1,0 +1,5 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew dependencies --write-locks
+empty=incomingCatalogForLibs0


### PR DESCRIPTION
This pull request modernizes and streamlines the build configuration for the JarHC Gradle Plugin project. The main changes involve introducing a centralized version catalog for dependencies and plugins, updating dependency declarations to use this catalog, and adding lockfiles for improved dependency management and reproducibility.

The version of the project has been updated to 3.1.0-SNAPSHOT. The goal is to keep the version of this JarHC Gradle plugin in sync with the version of the embedded JarHC library.