### PR TITLE
project/gradle10-compatibility

### DIFF
--- a/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
+++ b/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
@@ -109,7 +109,10 @@ class JarhcGradlePluginFunctionalTest {
 		GradleRunner runner = GradleRunner.create();
 		runner.forwardOutput();
 		runner.withPluginClasspath();
-		runner.withArguments("jarhcReport", "--stacktrace"); // "--info"
+		// --warning-mode=all surfaces Gradle deprecations; --configuration-cache fails
+		// the build on any configuration cache violation, guarding against regressions
+		// (e.g. accessing Task.project at execution time) that break Gradle 10 compatibility
+		runner.withArguments("jarhcReport", "--stacktrace", "--warning-mode=all", "--configuration-cache"); // "--info"
 		runner.withProjectDir(projectDir);
 		return runner.build();
 	}

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -53,8 +53,8 @@ public class JarhcGradlePlugin implements Plugin<Project> {
 		// configured on the task always wins, regardless of plugin apply order.
 		project.getPluginManager().withPlugin("java", plugin ->
 				task.getClasspath().convention(project.getConfigurations().named("runtimeClasspath")));
-		task.getProvided().setFrom();
-		task.getRuntime().setFrom();
+		// provided and runtime are left at their default (empty) instead of being
+		// set explicitly, so configuration on the task is never overwritten
 		task.getSections().empty();
 		task.getSkipEmpty().set(false);
 		task.getSortRows().set(false);

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -46,7 +46,11 @@ public class JarhcGradlePlugin implements Plugin<Project> {
 		Provider<RegularFile> textReportFile = buildDir.file("reports/jarhc/jarhc-report.txt");
 
 		// apply default configuration
-		task.getClasspath().setFrom();
+		// default the classpath to the project's runtime classpath, wired at
+		// configuration time so the task never accesses Task.project at execution
+		// time (which is deprecated and removed for the configuration cache)
+		project.getPluginManager().withPlugin("java", plugin ->
+				task.getClasspath().setFrom(project.getConfigurations().named("runtimeClasspath")));
 		task.getProvided().setFrom();
 		task.getRuntime().setFrom();
 		task.getSections().empty();

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -48,9 +48,11 @@ public class JarhcGradlePlugin implements Plugin<Project> {
 		// apply default configuration
 		// default the classpath to the project's runtime classpath, wired at
 		// configuration time so the task never accesses Task.project at execution
-		// time (which is deprecated and removed for the configuration cache)
+		// time (which is deprecated and removed for the configuration cache).
+		// convention() is used instead of setFrom() so an explicit classpath
+		// configured on the task always wins, regardless of plugin apply order.
 		project.getPluginManager().withPlugin("java", plugin ->
-				task.getClasspath().setFrom(project.getConfigurations().named("runtimeClasspath")));
+				task.getClasspath().convention(project.getConfigurations().named("runtimeClasspath")));
 		task.getProvided().setFrom();
 		task.getRuntime().setFrom();
 		task.getSections().empty();

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.util.List;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -102,11 +100,10 @@ public abstract class JarhcReportTask extends DefaultTask {
 	@TaskAction
 	void run() {
 
-		Project project = getProject();
-		Logger logger = project.getLogger();
+		Logger logger = getLogger();
 		logger.info("JarHC Report Task");
 
-		Options options = createOptions(project, logger);
+		Options options = createOptions(logger);
 
 		int exitCode = runJarHC(options, logger);
 		logger.info("JarHC exit code: {}", exitCode);
@@ -118,15 +115,11 @@ public abstract class JarhcReportTask extends DefaultTask {
 	}
 
 	// visible for testing
-	Options createOptions(Project project, Logger logger) {
+	Options createOptions(Logger logger) {
 
 		Options options = new Options();
 
 		FileCollection classpath = getClasspath();
-		if (classpath == null || classpath.isEmpty()) {
-			ConfigurationContainer configurations = project.getConfigurations();
-			classpath = configurations.getByName("runtimeClasspath");
-		}
 		logger.info("Classpath:");
 		for (File file : classpath) {
 			options.addClasspathJarPath(file.getAbsolutePath());

--- a/jarhc-gradle-plugin/src/test/java/org/jarhc/gradle/JarhcGradlePluginTest.java
+++ b/jarhc-gradle-plugin/src/test/java/org/jarhc/gradle/JarhcGradlePluginTest.java
@@ -31,8 +31,6 @@ import java.util.List;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -59,9 +57,6 @@ import org.mockito.quality.Strictness;
 class JarhcGradlePluginTest {
 
 	@Mock
-	Project project;
-
-	@Mock
 	Logger logger;
 
 	@Mock
@@ -70,16 +65,8 @@ class JarhcGradlePluginTest {
 	@BeforeEach
 	void setUp() {
 
-		// setup: project
-		when(project.getLogger()).thenReturn(logger);
-		ConfigurationContainer configurations = mock(ConfigurationContainer.class);
-		when(project.getConfigurations()).thenReturn(configurations);
-		Configuration configuration = mock(Configuration.class);
-		when(configurations.getByName("runtimeClasspath")).thenReturn(configuration);
-		when(configuration.iterator()).thenReturn(List.of(new File("/jarhc/a.jar")).iterator());
-
 		// setup: task
-		when(task.getProject()).thenReturn(project);
+		when(task.getLogger()).thenReturn(logger);
 
 	}
 
@@ -110,7 +97,7 @@ class JarhcGradlePluginTest {
 		Options options = new Options();
 
 		// prepare: task
-		when(task.createOptions(project, logger)).thenReturn(options);
+		when(task.createOptions(logger)).thenReturn(options);
 		when(task.runJarHC(options, logger)).thenReturn(0);
 		doCallRealMethod().when(task).run();
 
@@ -130,7 +117,7 @@ class JarhcGradlePluginTest {
 		Options options = new Options();
 
 		// prepare: task
-		when(task.createOptions(project, logger)).thenReturn(options);
+		when(task.createOptions(logger)).thenReturn(options);
 		when(task.runJarHC(options, logger)).thenReturn(123);
 		doCallRealMethod().when(task).run();
 
@@ -168,7 +155,9 @@ class JarhcGradlePluginTest {
 	void createOptions_withDefaultConfig() {
 
 		// prepare: task
-		when(task.getClasspath()).thenReturn(null);
+		ConfigurableFileCollection classpath = mock(ConfigurableFileCollection.class);
+		when(classpath.iterator()).thenReturn(List.of(new File("/jarhc/a.jar")).iterator());
+		when(task.getClasspath()).thenReturn(classpath);
 
 		when(task.getProvided()).thenReturn(null);
 
@@ -223,10 +212,10 @@ class JarhcGradlePluginTest {
 
 		when(task.getReportFiles()).thenReturn(null);
 
-		when(task.createOptions(project, logger)).thenCallRealMethod();
+		when(task.createOptions(logger)).thenCallRealMethod();
 
 		// test
-		Options options = task.createOptions(project, logger);
+		Options options = task.createOptions(logger);
 
 		// assert
 		assertNotNull(options);
@@ -322,10 +311,10 @@ class JarhcGradlePluginTest {
 		when(reportFiles.iterator()).thenReturn(List.of(new File("/jarhc/report.html"), new File("/jarhc/report.txt")).iterator());
 		when(task.getReportFiles()).thenReturn(reportFiles);
 
-		when(task.createOptions(project, logger)).thenCallRealMethod();
+		when(task.createOptions(logger)).thenCallRealMethod();
 
 		// test
-		Options options = task.createOptions(project, logger);
+		Options options = task.createOptions(logger);
 
 		// assert
 		assertNotNull(options);


### PR DESCRIPTION
This pull request refactors the Gradle plugin to improve compatibility with Gradle 10 and the configuration cache by removing deprecated usage of `Task.project` at execution time. The changes ensure all configuration is wired at configuration time, update tests accordingly, and add stricter checks in functional tests.