### PR TITLE
project/minimum-gradle-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Gradle plugin to generate a [JarHC - JAR Health Check](https://jarhc.org) report
 
 ## Installation
 
+The plugin requires **Gradle 8.8** or later.
+
 Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) for Kotlin:
 
 ```kotlin
 plugins {
-    id("org.jarhc") version "1.2.0"
+    id("org.jarhc") version "3.1.0"
 }
 ```
 

--- a/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
+++ b/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
@@ -29,11 +29,18 @@ import java.nio.file.Path;
 import org.gradle.internal.impldep.org.apache.commons.io.IOUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("DuplicatedCode")
 class JarhcGradlePluginFunctionalTest {
+
+	// minimum supported Gradle version (keep in sync with README and docs)
+	static final String MINIMUM_GRADLE_VERSION = "8.8";
+
+	// sentinel for the Gradle version running this build (the Gradle wrapper)
+	private static final String CURRENT_GRADLE_VERSION = "current";
 
 	@TempDir
 	File projectDir;
@@ -46,8 +53,9 @@ class JarhcGradlePluginFunctionalTest {
 		return new File(projectDir, "settings.gradle.kts");
 	}
 
-	@Test
-	void canRunTask_withDefaultConfig() throws IOException {
+	@ParameterizedTest(name = "Gradle {0}")
+	@ValueSource(strings = { CURRENT_GRADLE_VERSION, MINIMUM_GRADLE_VERSION })
+	void canRunTask_withDefaultConfig(String gradleVersion) throws IOException {
 
 		// prepare
 		String projectPath = "projects/default-config";
@@ -60,7 +68,7 @@ class JarhcGradlePluginFunctionalTest {
 		String expectedTextReport = readTextResource(projectPath + "/expected-report.txt");
 
 		// test
-		BuildResult result = runTask();
+		BuildResult result = runTask(gradleVersion);
 
 		// assert
 		String output = result.getOutput();
@@ -77,8 +85,9 @@ class JarhcGradlePluginFunctionalTest {
 		System.out.println(textReport);
 	}
 
-	@Test
-	void canRunTask_withFullConfig() throws IOException {
+	@ParameterizedTest(name = "Gradle {0}")
+	@ValueSource(strings = { CURRENT_GRADLE_VERSION, MINIMUM_GRADLE_VERSION })
+	void canRunTask_withFullConfig(String gradleVersion) throws IOException {
 
 		// prepare
 		String projectPath = "projects/full-config";
@@ -91,7 +100,7 @@ class JarhcGradlePluginFunctionalTest {
 		String expectedTextReport = readTextResource(projectPath + "/expected-report.txt");
 
 		// test
-		BuildResult result = runTask();
+		BuildResult result = runTask(gradleVersion);
 
 		// assert
 		String output = result.getOutput();
@@ -105,10 +114,15 @@ class JarhcGradlePluginFunctionalTest {
 		System.out.println(textReport);
 	}
 
-	private BuildResult runTask() {
+	private BuildResult runTask(String gradleVersion) {
 		GradleRunner runner = GradleRunner.create();
 		runner.forwardOutput();
 		runner.withPluginClasspath();
+		// run against the minimum supported Gradle version as well as the current
+		// one, so the documented floor stays honest as the code evolves
+		if (!CURRENT_GRADLE_VERSION.equals(gradleVersion)) {
+			runner.withGradleVersion(gradleVersion);
+		}
 		// --warning-mode=all surfaces Gradle deprecations; --configuration-cache fails
 		// the build on any configuration cache violation, guarding against regressions
 		// (e.g. accessing Task.project at execution time) that break Gradle 10 compatibility


### PR DESCRIPTION
## Summary

Documents and continuously verifies the plugin's minimum supported Gradle version.

The `convention()` default-classpath wiring introduced in #48 raised the plugin's
runtime floor to **Gradle 8.8**, because `ConfigurableFileCollection.convention()`
was added in that version. Under older Gradle the `jarhcReport` task fails at
configuration time with `NoSuchMethodError`.

## Changes

- **README**: document that the plugin requires Gradle 8.8 or later.
- **Functional tests**: parameterize both scenarios (`default-config` and
  `full-config`) over `{ current, 8.8 }` using `GradleRunner.withGradleVersion(...)`,
  with the minimum as a shared constant (`MINIMUM_GRADLE_VERSION`). Running the
  full-config scenario (which sets every property and exercises all `createOptions`
  branches) against 8.8 keeps the documented floor honest: if an API newer than 8.8
  is introduced in any exercised branch, the `8.8` invocation fails the build.

## Verification

- `./gradlew :jarhc-gradle-plugin:build` is green.
- All four functional invocations pass: default-config and full-config, each on
  `current` and `8.8`.
- The floor was also confirmed empirically with a one-off probe: Gradle 8.7 fails on
  `convention()`, Gradle 8.8 passes (including `--configuration-cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
