### PR TITLE
feature/enforce-minimum-gradle-version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ short bullet lists of facts, minimal prose. Preserve this style when editing it.
 - Plugin bytecode: Java 11.
 - Tests run on: Java 17 (Gradle 9 TestKit requires it).
 - Gradle wrapper: 9.6.1 (requires Java 17 to run).
-- Minimum supported Gradle: 8.8 (`MINIMUM_GRADLE_VERSION` in the functional test).
+- Minimum supported Gradle: 8.8 (`MINIMUM_GRADLE_VERSION` in `JarhcGradlePlugin`).
 
 ## Compatibility (enforced by the functional tests)
 

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -134,8 +134,12 @@ tasks.build {
 // tests -----------------------------------------------------------------------
 
 // source set for the functional test suite
-val functionalTestSourceSet = sourceSets.create("functionalTest") {
-}
+val functionalTestSourceSet = sourceSets.create("functionalTest")
+
+// compile and run the functional tests against the plugin's main classes so they
+// can reference constants such as JarhcGradlePlugin.MINIMUM_GRADLE_VERSION
+functionalTestSourceSet.compileClasspath += sourceSets["main"].output
+functionalTestSourceSet.runtimeClasspath += sourceSets["main"].output
 
 configurations["functionalTestImplementation"].extendsFrom(configurations["testImplementation"])
 configurations["functionalTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])

--- a/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
+++ b/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
@@ -37,11 +37,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 @SuppressWarnings("DuplicatedCode")
 class JarhcGradlePluginFunctionalTest {
 
-	// minimum supported Gradle version (keep in sync with README and docs)
-	static final String MINIMUM_GRADLE_VERSION = "8.8";
-
 	// sentinel for the Gradle version running this build (the Gradle wrapper)
 	private static final String CURRENT_GRADLE_VERSION = "current";
+
+	// a released Gradle version below JarhcGradlePlugin.MINIMUM_GRADLE_VERSION,
+	// used to verify the version guard; it does not need to track the minimum
+	private static final String BELOW_MINIMUM_GRADLE_VERSION = "8.7";
 
 	@TempDir
 	File projectDir;
@@ -55,7 +56,7 @@ class JarhcGradlePluginFunctionalTest {
 	}
 
 	@ParameterizedTest(name = "Gradle {0}")
-	@ValueSource(strings = { CURRENT_GRADLE_VERSION, MINIMUM_GRADLE_VERSION })
+	@ValueSource(strings = { CURRENT_GRADLE_VERSION, JarhcGradlePlugin.MINIMUM_GRADLE_VERSION })
 	void canRunTask_withDefaultConfig(String gradleVersion) throws IOException {
 
 		// prepare
@@ -87,7 +88,7 @@ class JarhcGradlePluginFunctionalTest {
 	}
 
 	@ParameterizedTest(name = "Gradle {0}")
-	@ValueSource(strings = { CURRENT_GRADLE_VERSION, MINIMUM_GRADLE_VERSION })
+	@ValueSource(strings = { CURRENT_GRADLE_VERSION, JarhcGradlePlugin.MINIMUM_GRADLE_VERSION })
 	void canRunTask_withFullConfig(String gradleVersion) throws IOException {
 
 		// prepare
@@ -127,13 +128,13 @@ class JarhcGradlePluginFunctionalTest {
 		BuildResult result = GradleRunner.create()
 				.forwardOutput()
 				.withPluginClasspath()
-				.withGradleVersion("8.7")
+				.withGradleVersion(BELOW_MINIMUM_GRADLE_VERSION)
 				.withArguments("jarhcReport")
 				.withProjectDir(projectDir)
 				.buildAndFail();
 
 		// assert: clear message instead of a cryptic NoSuchMethodError
-		assertTrue(result.getOutput().contains("requires Gradle 8.8 or later"));
+		assertTrue(result.getOutput().contains("requires Gradle " + JarhcGradlePlugin.MINIMUM_GRADLE_VERSION + " or later"));
 	}
 
 	private BuildResult runTask(String gradleVersion) {

--- a/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
+++ b/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import org.gradle.internal.impldep.org.apache.commons.io.IOUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -112,6 +113,27 @@ class JarhcGradlePluginFunctionalTest {
 		String textReport = Files.readString(expectedTextReportPath);
 		assertEquals(expectedTextReport, textReport);
 		System.out.println(textReport);
+	}
+
+	@Test
+	void failsWithClearMessageBelowMinimumGradleVersion() throws IOException {
+
+		// prepare: a minimal project that applies the plugin
+		String projectPath = "projects/default-config";
+		writeTextFile(getSettingsFile(), readTextResource(projectPath + "/settings.gradle.kts"));
+		writeTextFile(getBuildFile(), readTextResource(projectPath + "/build.gradle.kts"));
+
+		// test: run against a Gradle version below the minimum supported version
+		BuildResult result = GradleRunner.create()
+				.forwardOutput()
+				.withPluginClasspath()
+				.withGradleVersion("8.7")
+				.withArguments("jarhcReport")
+				.withProjectDir(projectDir)
+				.buildAndFail();
+
+		// assert: clear message instead of a cryptic NoSuchMethodError
+		assertTrue(result.getOutput().contains("requires Gradle 8.8 or later"));
 	}
 
 	private BuildResult runTask(String gradleVersion) {

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -15,16 +15,23 @@
  */
 package org.jarhc.gradle;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.util.GradleVersion;
 
 public class JarhcGradlePlugin implements Plugin<Project> {
 
 	public void apply(Project project) {
+
+		// fail fast with a clear message on unsupported Gradle versions
+		if (GradleVersion.current().compareTo(GradleVersion.version("8.8")) < 0) {
+			throw new GradleException("The JarHC Gradle plugin requires Gradle 8.8 or later.");
+		}
 
 		// register jarhcReport task
 		project.getTasks().register("jarhcReport", JarhcReportTask.class, task -> setDefaultConfiguration(task, project));

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -29,6 +29,7 @@ public class JarhcGradlePlugin implements Plugin<Project> {
 	// minimum supported Gradle version
 	static final String MINIMUM_GRADLE_VERSION = "8.8";
 
+	@Override
 	public void apply(Project project) {
 
 		// fail fast with a clear message on unsupported Gradle versions

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -26,11 +26,14 @@ import org.gradle.util.GradleVersion;
 
 public class JarhcGradlePlugin implements Plugin<Project> {
 
+	// minimum supported Gradle version
+	static final String MINIMUM_GRADLE_VERSION = "8.8";
+
 	public void apply(Project project) {
 
 		// fail fast with a clear message on unsupported Gradle versions
-		if (GradleVersion.current().compareTo(GradleVersion.version("8.8")) < 0) {
-			throw new GradleException("The JarHC Gradle plugin requires Gradle 8.8 or later.");
+		if (GradleVersion.current().compareTo(GradleVersion.version(MINIMUM_GRADLE_VERSION)) < 0) {
+			throw new GradleException("The JarHC Gradle plugin requires Gradle " + MINIMUM_GRADLE_VERSION + " or later.");
 		}
 
 		// register jarhcReport task


### PR DESCRIPTION
## Summary

Fails fast with a clear message when the plugin is applied on a Gradle version below
the minimum supported version (8.8).

The plugin uses `ConfigurableFileCollection.convention()`, which was added in Gradle
8.8. On older Gradle the `jarhcReport` task failed at configuration time with a
cryptic `NoSuchMethodError`. A guard in `JarhcGradlePlugin.apply()` now checks the
running Gradle version and throws a clear `GradleException` instead:

> The JarHC Gradle plugin requires Gradle 8.8 or later.

## Changes

- **JarhcGradlePlugin**: `GradleVersion.current()` guard at the start of `apply()`.
- **Functional test**: a test that applies the plugin on Gradle 8.7 and asserts the
  clear message (`buildAndFail`).

## Verification

- `./gradlew :jarhc-gradle-plugin:build` is green.
- On Gradle 8.7 the build now fails with "Failed to apply plugin 'org.jarhc'. The
  JarHC Gradle plugin requires Gradle 8.8 or later." instead of `NoSuchMethodError`.
- The existing matrix tests still pass on the current Gradle and on 8.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
