### PR TITLE
project/remove-grgit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ mockito = "5.23.0"
 ben-manes-versions = "0.54.0"
 plugin-publish = "2.1.1"
 sonarqube = "7.3.1.8318"
-grgit = "5.3.3"
 
 [libraries]
 jarhc = { module = "org.jarhc:jarhc", version.ref = "jarhc" }
@@ -20,4 +19,3 @@ mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.
 versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
-grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -27,9 +27,6 @@ plugins {
 
     // run Sonar analysis
     alias(libs.plugins.sonarqube)
-
-    // get current Git branch name
-    alias(libs.plugins.grgit)
 }
 
 // Preconditions based on which tasks should be executed -----------------------
@@ -275,5 +272,10 @@ tasks.sonar {
 // helper functions ------------------------------------------------------------
 
 fun getGitBranchName(): String {
-    return grgit.branch.current().name
+    val head = rootDir.resolve(".git/HEAD")
+    if (head.isFile) {
+        val content = head.readText(Charsets.UTF_8).trim()
+        return content.removePrefix("ref: refs/heads/")
+    }
+    throw GradleException("Git branch name not found.")
 }

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -272,7 +272,13 @@ tasks.sonar {
 // helper functions ------------------------------------------------------------
 
 fun getGitBranchName(): String {
-    val head = rootDir.resolve(".git/HEAD")
+    var gitDir = rootDir.resolve(".git")
+    // In worktrees and submodules, .git is a file: "gitdir: <path>"
+    if (gitDir.isFile) {
+        val gitdir = gitDir.readText(Charsets.UTF_8).trim().removePrefix("gitdir: ")
+        gitDir = rootDir.resolve(gitdir)
+    }
+    val head = gitDir.resolve("HEAD")
     if (head.isFile) {
         val content = head.readText(Charsets.UTF_8).trim()
         return content.removePrefix("ref: refs/heads/")

--- a/jarhc-gradle-plugin/buildscript-gradle.lockfile
+++ b/jarhc-gradle-plugin/buildscript-gradle.lockfile
@@ -4,7 +4,6 @@
 # To regenerate this file, run: ./gradlew dependencies --write-locks
 com.google.code.gson:gson:2.13.2=classpath
 com.google.errorprone:error_prone_annotations:2.41.0=classpath
-com.googlecode.javaewah:JavaEWAH:1.2.3=classpath
 com.gradle.plugin-publish:com.gradle.plugin-publish.gradle.plugin:2.1.1=classpath
 com.gradle.publish:plugin-publish-plugin:2.1.1=classpath
 commons-codec:commons-codec:1.19.0=classpath
@@ -12,16 +11,11 @@ commons-io:commons-io:2.20.0=classpath
 de.siegmar:fastcsv:3.7.0=classpath
 io.github.hakky54:ayza:10.0.3=classpath
 io.github.hakky54:sude:2.0.2=classpath
-org.ajoberstar.grgit:grgit-core:5.3.3=classpath
-org.ajoberstar.grgit:grgit-gradle:5.3.3=classpath
-org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin:5.3.3=classpath
 org.apache.commons:commons-compress:1.28.0=classpath
 org.apache.commons:commons-lang3:3.20.0=classpath
 org.apache.maven:maven-model:3.6.3=classpath
 org.bouncycastle:bcprov-jdk18on:1.84=classpath
-org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r=classpath
 org.gradle.plugin:compatibility-plugin:1.0.0=classpath
-org.slf4j:slf4j-api:1.7.36=classpath
 org.sonarqube:org.sonarqube.gradle.plugin:7.3.1.8318=classpath
 org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:7.3.1.8318=classpath
 org.sonarsource.scanner.lib:sonar-scanner-download-cache:4.1.1.1633=classpath


### PR DESCRIPTION
## Summary

Removes the `org.ajoberstar.grgit` Gradle plugin, which existed only to read the current Git branch name for the Sonar branch properties.

Replaces it with a small `getGitBranchName()` helper that reads `.git/HEAD` directly — the same approach already used in the jarhc core build (`jarhc/build.gradle.kts`), keeping the two repos consistent.

## Changes

- Drop the `grgit` plugin alias from `jarhc-gradle-plugin/build.gradle.kts`.
- Reimplement `getGitBranchName()` to parse `.git/HEAD`.
- Remove the `grgit` version and plugin entries from `gradle/libs.versions.toml`.
- Refresh `buildscript-gradle.lockfile` (drops three grgit classpath entries).

## Notes / trade-off

In a detached-HEAD state the helper returns the raw commit SHA (grgit resolved more edge cases). This is fine for Sonar branch naming and matches the core build's behavior.

## Verification

- `./gradlew build` — passes.
- `./gradlew updateGradleLockfiles --write-locks` — lockfile updated, no grgit entries remain.
- Confirmed the helper resolves `.git/HEAD` to the expected branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)