### PR TITLE
project/cleanup-build-scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 build/
 
 # user-specific files
-gradle.user.properties
 *.gpg
 
 # macOS files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.util.*
 
 plugins {
     idea
@@ -67,16 +66,6 @@ allprojects {
     // lock all dependency configurations in every project ---------------------
     dependencyLocking {
         lockAllConfigurations()
-    }
-
-    // load user-specific properties -------------------------------------------
-    val userPropertiesFile = file("${rootDir}/gradle.user.properties")
-    if (userPropertiesFile.exists()) {
-        val userProperties = Properties()
-        userProperties.load(userPropertiesFile.inputStream())
-        userProperties.forEach {
-            project.ext.set(it.key.toString(), it.value)
-        }
     }
 
     repositories {

--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -80,7 +80,7 @@ gradlePlugin {
 
 // flag to skip unit and integration tests
 // command line option: -Pskip.tests
-val skipTests: Boolean = project.hasProperty("skip.tests")
+val skipTests = providers.gradleProperty("skip.tests").isPresent
 
 // Java ------------------------------------------------------------------------
 
@@ -147,13 +147,13 @@ gradlePlugin.testSourceSets(functionalTestSourceSet)
 // 'jarhc.*' Gradle properties to pass as system properties to the JUnit JVM
 val jarhcProperties = providers.gradlePropertiesPrefixedBy("jarhc.")
 
-tasks.withType(Test::class) {
+tasks.withType<Test>().configureEach {
 
     // run tests on Java 17 (Gradle 9 test fixtures require Java 17)
     javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(17)) })
 
     // skip tests if property "skip.tests" is set
-    onlyIf { !skipTests }
+    if (skipTests) enabled = false
 
     // use JUnit
     useJUnitPlatform()


### PR DESCRIPTION
Clean up the Gradle build scripts by removing an unused mechanism and modernizing the test-skip flag.

## Remove the `gradle.user.properties` loader
The root build read an optional `gradle.user.properties` and injected its entries as project
extra properties. Nothing in the build depends on it: personal and release credentials live in
`~/.gradle/gradle.properties`, and the only property consumer (`skip.tests`) does not need it.
Removed the loader, its now-unused `import java.util.*`, and the obsolete `.gitignore` entry.

## Modernize the `skip.tests` flag
Reworked the `-Pskip.tests` handling to be configuration-cache friendly:

- Read the flag via `providers.gradleProperty("skip.tests")` instead of the legacy
  `project.hasProperty(...)`.
- Skip tests by setting `enabled = false` at configuration time instead of an execution-time
  `onlyIf { !skipTests }`, which captured script state and is not configuration-cache compatible.
- Configure the test tasks lazily via `withType<Test>().configureEach { }`.

Behavior is unchanged: `-Pskip.tests` still skips the test tasks (verified: `:test` reports
`SKIPPED`), and the configuration cache now stores an entry cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)