### PR TITLE
code/resolve-sonar-issues

### DIFF
--- a/jarhc-gradle-plugin/build.gradle.kts
+++ b/jarhc-gradle-plugin/build.gradle.kts
@@ -58,8 +58,8 @@ dependencies {
 
     // JUnit and Mockito
     testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.mockito.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 gradlePlugin {

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
@@ -92,6 +92,8 @@ public abstract class JarhcReportTask extends DefaultTask {
 	@Inject
 	public abstract WorkerExecutor getWorkerExecutor();
 
+	// Gradle instantiates task types via dependency injection and requires a public
+	// (or @Inject-annotated) constructor, so this cannot be reduced to protected.
 	public JarhcReportTask() {
 		setGroup("verification");
 		setDescription("Generates a JarHC report.");

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
@@ -92,8 +92,9 @@ public abstract class JarhcReportTask extends DefaultTask {
 	@Inject
 	public abstract WorkerExecutor getWorkerExecutor();
 
-	// Gradle instantiates task types via dependency injection and requires a public
-	// (or @Inject-annotated) constructor, so this cannot be reduced to protected.
+	// Sonar suggests making this constructor protected, but Gradle can only instantiate task types via a
+	// public no-arg constructor or a constructor annotated with @Inject (public or protected).
+	// Keeping it public avoids TaskInstantiationException during task creation.
 	public JarhcReportTask() {
 		setGroup("verification");
 		setDescription("Generates a JarHC report.");

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcRunner.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcRunner.java
@@ -17,6 +17,7 @@ package org.jarhc.gradle;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.jarhc.app.Application;
@@ -65,30 +66,9 @@ final class JarhcRunner {
 
 		Options options = new Options();
 
-		FileCollection classpath = parameters.getClasspath();
-		logger.info("Classpath:");
-		for (File file : classpath) {
-			options.addClasspathJarPath(file.getAbsolutePath());
-			logger.info("- {}", logger.isDebugEnabled() ? file.getAbsolutePath() : file.getName());
-		}
-
-		FileCollection provided = parameters.getProvided();
-		if (provided != null && !provided.isEmpty()) {
-			logger.info("Provided:");
-			for (File file : provided) {
-				options.addProvidedJarPath(file.getAbsolutePath());
-				logger.info("- {}", logger.isDebugEnabled() ? file.getAbsolutePath() : file.getName());
-			}
-		}
-
-		FileCollection runtime = parameters.getRuntime();
-		if (runtime != null && !runtime.isEmpty()) {
-			logger.info("Runtime:");
-			for (File file : runtime) {
-				options.addRuntimeJarPath(file.getAbsolutePath());
-				logger.info("- {}", logger.isDebugEnabled() ? file.getAbsolutePath() : file.getName());
-			}
-		}
+		logAndAddJars(parameters.getClasspath(), "Classpath", options::addClasspathJarPath, logger);
+		logAndAddJars(parameters.getProvided(), "Provided", options::addProvidedJarPath, logger);
+		logAndAddJars(parameters.getRuntime(), "Runtime", options::addRuntimeJarPath, logger);
 
 		if (parameters.getSections().isPresent() && !parameters.getSections().get().isEmpty()) {
 			List<String> sections = parameters.getSections().get();
@@ -140,16 +120,27 @@ final class JarhcRunner {
 			options.setReportTitle(reportTitle);
 		}
 
-		FileCollection reportFiles = parameters.getReportFiles();
-		if (reportFiles != null && !reportFiles.isEmpty()) {
-			for (File reportFile : reportFiles) {
-				String path = reportFile.getAbsolutePath();
-				logger.info("Report file: {}", path);
-				options.addReportFile(path);
-			}
-		}
+		addReportFiles(options, parameters.getReportFiles(), logger);
 
 		return options;
+	}
+
+	private static void logAndAddJars(FileCollection files, String label, Consumer<String> add, Logger logger) {
+		if (files == null || files.isEmpty()) return;
+		logger.info("{}:", label);
+		for (File file : files) {
+			add.accept(file.getAbsolutePath());
+			logger.info("- {}", logger.isDebugEnabled() ? file.getAbsolutePath() : file.getName());
+		}
+	}
+
+	private static void addReportFiles(Options options, FileCollection reportFiles, Logger logger) {
+		if (reportFiles == null || reportFiles.isEmpty()) return;
+		for (File reportFile : reportFiles) {
+			String path = reportFile.getAbsolutePath();
+			logger.info("Report file: {}", path);
+			options.addReportFile(path);
+		}
 	}
 
 	// visible for testing


### PR DESCRIPTION
Address the three SonarQube issues reported on the plugin, one commit each.

## 1. Group test dependencies by configuration (`build.gradle.kts`)
Reordered so the `testRuntimeOnly` declaration no longer splits the `testImplementation`
group. Cosmetic, no behavior change.

## 2. `JarhcReportTask` constructor visibility — false positive (documented)
Sonar (rule S5993) suggests making the abstract task's constructor `protected`. That is a
**false positive** for a Gradle task type: Gradle instantiates tasks via dependency injection
and requires a `public` (or `@Inject`-annotated) constructor. Making it `protected` fails the
build with `TaskInstantiationException: ... has no constructor that is annotated with @Inject`.
The constructor stays `public`; a comment now records why. **Please mark this issue as a false
positive in SonarCloud.**

## 3. Reduce Cognitive Complexity in `JarhcRunner.createOptions` (32 -> under 15)
The classpath / provided / runtime blocks were near-identical loops (plus a fourth for report
files). Extracted `logAndAddJars` and `addReportFiles` helpers, removing the duplication and
bringing the method under the threshold. Behavior is unchanged except that an empty JAR
collection now logs nothing instead of an empty header (loggers are mocked in the unit tests,
which still pass).

Verified locally: `./gradlew build` passes (unit + functional + plugin validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)