### PR TITLE
project/next-snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # PROJECT ----------------------------------------------------------------------
 
 group = org.jarhc.gradle
-version = 3.1.0
+version = 3.1.1-SNAPSHOT
 description = JarHC Gradle Plugin
 
 # GRADLE SETTINGS --------------------------------------------------------------


### PR DESCRIPTION
Sets the version back to a snapshot after the 3.1.0 release, so ongoing development on `main` targets the next version.

- Change the project version from `3.1.0` to `3.1.1-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
