### PR TITLE
bugfix/spurious-deprecation-warnings

### DIFF
--- a/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
+++ b/jarhc-gradle-plugin/src/functionalTest/java/org/jarhc/gradle/JarhcGradlePluginFunctionalTest.java
@@ -16,6 +16,7 @@
 package org.jarhc.gradle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -75,6 +76,8 @@ class JarhcGradlePluginFunctionalTest {
 		// assert
 		String output = result.getOutput();
 		assertTrue(output.contains(expectedOutput));
+		// the default configuration sets no deprecated option, so none is reported
+		assertFalse(output.contains("has been deprecated and is ignored"));
 		assertTrue(Files.isDirectory(expectedDataPath));
 		assertTrue(Files.isRegularFile(expectedHtmlReportPath));
 		assertTrue(Files.isRegularFile(expectedTextReportPath));
@@ -107,6 +110,10 @@ class JarhcGradlePluginFunctionalTest {
 		// assert
 		String output = result.getOutput();
 		assertTrue(output.contains(expectedOutput));
+		// the full configuration sets all three deprecated options, so each is reported
+		assertTrue(output.contains("Option 'sortRows' has been deprecated and is ignored."));
+		assertTrue(output.contains("Option 'removeVersion' has been deprecated and is ignored."));
+		assertTrue(output.contains("Option 'useArtifactName' has been deprecated and is ignored."));
 		assertTrue(Files.isDirectory(expectedDataPath));
 		assertTrue(Files.isRegularFile(expectedHtmlReportPath));
 		assertTrue(Files.isRegularFile(expectedTextReportPath));

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcGradlePlugin.java
@@ -97,11 +97,11 @@ public class JarhcGradlePlugin implements Plugin<Project> {
 		// set explicitly, so configuration on the task is never overwritten
 		task.getSections().empty();
 		task.getSkipEmpty().set(false);
-		task.getSortRows().set(false);
+		// deprecated options (sortRows, removeVersion, useArtifactName) are left unset
+		// on purpose: a value would make isPresent() true and trigger a spurious
+		// deprecation warning even though the user never configured the option
 		task.getRelease().set(-1);
 		task.getStrategy().set("ParentLast");
-		task.getRemoveVersion().set(false);
-		task.getUseArtifactName().set(false);
 		task.getIgnoreMissingAnnotations().set(false);
 		task.getIgnoreExactCopy().set(false);
 		task.getDataDir().set(dataDir);

--- a/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
+++ b/jarhc-gradle-plugin/src/main/java/org/jarhc/gradle/JarhcReportTask.java
@@ -59,7 +59,10 @@ public abstract class JarhcReportTask extends DefaultTask {
 	@Input
 	public abstract Property<Boolean> getSkipEmpty();
 
-	@Input
+	// Deprecated and ignored. @Internal (not @Input) so it needs no default value
+	// and isPresent() is true only when the user explicitly sets it, which triggers
+	// a deprecation warning in run().
+	@Internal
 	public abstract Property<Boolean> getSortRows();
 
 	@Input
@@ -68,10 +71,12 @@ public abstract class JarhcReportTask extends DefaultTask {
 	@Input
 	public abstract Property<String> getStrategy();
 
-	@Input
+	// Deprecated and ignored (see getSortRows).
+	@Internal
 	public abstract Property<Boolean> getRemoveVersion();
 
-	@Input
+	// Deprecated and ignored (see getSortRows).
+	@Internal
 	public abstract Property<Boolean> getUseArtifactName();
 
 	@Input

--- a/jarhc-gradle-plugin/src/test/java/org/jarhc/gradle/JarhcGradlePluginTest.java
+++ b/jarhc-gradle-plugin/src/test/java/org/jarhc/gradle/JarhcGradlePluginTest.java
@@ -16,6 +16,7 @@
 package org.jarhc.gradle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -69,6 +70,24 @@ class JarhcGradlePluginTest {
 		// assert: the task classpath defaults to the project's runtime classpath
 		FileCollection runtimeClasspath = project.getConfigurations().getByName("runtimeClasspath");
 		assertEquals(runtimeClasspath.getFiles(), task.getClasspath().getFiles());
+	}
+
+	@Test
+	void apply_leavesDeprecatedOptionsUnset() {
+
+		// prepare
+		Project project = ProjectBuilder.builder().build();
+		project.getPlugins().apply("org.jarhc");
+
+		// test: realize the task, which runs the default configuration
+		JarhcReportTask task = (JarhcReportTask) project.getTasks().getByName("jarhcReport");
+
+		// assert: the deprecated options are left unset by the default configuration,
+		// so run() does not log a spurious deprecation warning when the user never
+		// configured them
+		assertFalse(task.getSortRows().isPresent());
+		assertFalse(task.getRemoveVersion().isPresent());
+		assertFalse(task.getUseArtifactName().isPresent());
 	}
 
 }


### PR DESCRIPTION
Fixes a bug in 3.1.0: the plugin logged spurious deprecation warnings for the `sortRows`, `removeVersion`, and `useArtifactName` options on every `jarhcReport` run, even when the user never configured them.

**Cause:** the plugin set default values on these deprecated properties to satisfy their `@Input` requirement, which made `Property.isPresent()` always return true, so `warnAboutDeprecatedOptions()` always fired.

**Fix:**
- Mark the three deprecated properties `@Internal` instead of `@Input` (they are ignored and never passed to the worker, so they are not task inputs).
- Drop the default values, so `isPresent()` is true only when the user explicitly sets an option.

**Tests:**
- Unit: `apply_leavesDeprecatedOptionsUnset` asserts the default configuration leaves the options unset.
- Functional: `default-config` asserts no deprecation warning is emitted; `full-config` asserts all three warnings are emitted when the options are set.

This is not tied to a release; it will ship with the next release, whenever that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
